### PR TITLE
Add anchor sections and smooth navigation to roadtrip page

### DIFF
--- a/roadtrip_usa_2026.html
+++ b/roadtrip_usa_2026.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr">
+<html lang="fr" class="scroll-smooth">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -14,44 +14,52 @@
     <div class="max-w-7xl mx-auto px-4">
       <div class="flex items-center justify-between h-16">
         <h1 class="text-xl font-bold">Road Trip USA 2026</h1>
-        <button id="mobile-menu-button" class="md:hidden p-2" aria-label="Menu">
-          <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-          </svg>
-        </button>
+        <nav class="flex space-x-4">
+          <a href="#accueil" class="hover:text-blue-500">Accueil</a>
+          <a href="#itineraire" class="hover:text-blue-500">Itinéraire</a>
+          <a href="#programme" class="hover:text-blue-500">Programme</a>
+          <a href="#infos" class="hover:text-blue-500">Infos</a>
+        </nav>
       </div>
     </div>
   </header>
 
-  <main>
-  <!-- Sidebar -->
-  <aside id="side-nav" class="side-nav p-4 hidden md:block">
-    <h2 class="text-lg font-semibold mb-4">Jours</h2>
-    <div id="nav-buttons" class="space-y-2"></div>
-  </aside>
+  <section id="accueil"></section>
+  <section id="itineraire"></section>
 
-  <!-- Content -->
-  <section id="content">
-    <!-- Map -->
-    <div id="map-container" class="h-64 mb-6"></div>
-    <p id="map-error" class="text-red-600 hidden">Impossible de charger la carte.</p>
+  <section id="programme">
+    <main>
+      <!-- Sidebar -->
+      <aside id="side-nav" class="side-nav p-4 hidden md:block">
+        <h2 class="text-lg font-semibold mb-4">Jours</h2>
+        <div id="nav-buttons" class="space-y-2"></div>
+      </aside>
 
-    <!-- Day details -->
-    <div id="day-content"></div>
+      <!-- Content -->
+      <section id="content">
+        <!-- Map -->
+        <div id="map-container" class="h-64 mb-6"></div>
+        <p id="map-error" class="text-red-600 hidden">Impossible de charger la carte.</p>
 
-    <!-- Infos pratiques -->
-    <section id="infos-pratiques" class="mt-8">
-      <h2 class="text-xl font-semibold mb-2">Infos pratiques</h2>
-      <ul class="list-disc list-inside space-y-1">
-        <li>Budget estimé : 2 800 €/personne</li>
-        <li>Météo : Été chaud, prévoir crème solaire et chapeau</li>
-        <li>Transports : Voiture de location incluse, conduite à droite</li>
-        <li>Hébergements : Cabane, lodge, hôtel — réservations incluses</li>
-        <li>Conseil : Télécharger l’application offline Maps.me pour le GPS</li>
-      </ul>
-    </section>
+        <!-- Day details -->
+        <div id="day-content"></div>
+
+        <!-- Infos pratiques -->
+        <section id="infos-pratiques" class="mt-8">
+          <h2 class="text-xl font-semibold mb-2">Infos pratiques</h2>
+          <ul class="list-disc list-inside space-y-1">
+            <li>Budget estimé : 2 800 €/personne</li>
+            <li>Météo : Été chaud, prévoir crème solaire et chapeau</li>
+            <li>Transports : Voiture de location incluse, conduite à droite</li>
+            <li>Hébergements : Cabane, lodge, hôtel — réservations incluses</li>
+            <li>Conseil : Télécharger l’application offline Maps.me pour le GPS</li>
+          </ul>
+        </section>
+      </section>
+    </main>
   </section>
-</main>
+
+  <section id="infos"></section>
 
 
   <footer class="bg-gray-800 text-white text-center p-4">


### PR DESCRIPTION
## Summary
- Add persistent navigation menu linking to new Accueil, Itinéraire, Programme and Infos sections.
- Wrap existing main content in `#programme` section and add empty anchor sections for landing.
- Enable smooth scrolling for in-page anchors.

## Testing
- `pytest` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_6893d0e0566c8320b913f5d81a4568fd