### PR TITLE
Add smooth scrolling and sticky navigation menu

### DIFF
--- a/static/css/roadtrip.css
+++ b/static/css/roadtrip.css
@@ -1,3 +1,7 @@
+html {
+  scroll-behavior: smooth;
+}
+
 body {
   display: flex;
   flex-direction: column;
@@ -28,4 +32,35 @@ main {
 }
 #day-content.hide {
   opacity: 0;
+}
+
+/* Background colors for main sections */
+#accueil {
+  background-color: #f9fafb;
+}
+
+#itineraire {
+  background-color: #f0f9ff;
+}
+
+#programme {
+  background-color: #fff7ed;
+}
+
+#infos {
+  background-color: #f5f5f5;
+}
+
+/* Sticky top-right navigation menu */
+header nav {
+  position: fixed;
+  top: 0.5rem;
+  right: 0.5rem;
+  background-color: rgba(255, 255, 255, 0.95);
+  padding: 0.5rem 1rem;
+  display: flex;
+  gap: 1rem;
+  border-radius: 0.5rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  z-index: 1000;
 }


### PR DESCRIPTION
## Summary
- add smooth scrolling to roadtrip page
- style main sections with light backgrounds
- implement fixed top-right navigation menu with spacing

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6893d24c5db08320b8d7291e957223de