### PR TITLE
Add site sections and navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
   <link rel="stylesheet" href="static/css/main.css" />
+  <link rel="stylesheet" href="static/css/roadtrip.css" />
   
 </head>
 <body class="bg-gray-50 text-gray-800">
@@ -20,79 +21,89 @@
           </svg>
         </button>
       </div>
+      <nav class="flex space-x-4 justify-center py-2">
+        <a href="#accueil">Accueil</a>
+        <a href="#itineraire">Itinéraire</a>
+        <a href="#programme">Programme</a>
+        <a href="#infos">Infos pratiques</a>
+      </nav>
     </div>
   </header>
 
-  <!-- Map section -->
-<section id="map" class="h-[400px] relative z-0">
-  <div id="map-container" class="w-full h-full"></div>
-</section>
+  <section id="accueil"></section>
 
-<!-- Main content -->
-<main class="min-h-screen relative">
-  <div class="flex">
-    <!-- Side navigation -->
-    <nav id="side-nav" class="side-nav w-72 bg-white shadow-lg h-[calc(100vh-200px)] sticky top-16 overflow-y-auto hidden md:block">
-      <div class="p-6">
-        <div class="text-2xl font-bold mb-6 text-blue-600">Programme du voyage</div>
-        <div id="days-nav" class="space-y-2">
-          <!-- Days navigation will be inserted here -->
+  <section id="itineraire" class="h-[400px] relative z-0">
+    <!-- carte interactive -->
+    <div id="map-container" class="w-full h-full"></div>
+  </section>
+
+  <section id="programme" class="min-h-screen relative">
+    <!-- programme dynamique -->
+    <div class="flex">
+      <!-- Side navigation -->
+      <nav id="side-nav" class="side-nav w-72 bg-white shadow-lg h-[calc(100vh-200px)] sticky top-16 overflow-y-auto hidden md:block">
+        <div class="p-6">
+          <div class="text-2xl font-bold mb-6 text-blue-600">Programme du voyage</div>
+          <div id="days-nav" class="space-y-2">
+            <!-- Days navigation will be inserted here -->
+          </div>
         </div>
-      </div>
-    </nav>
+      </nav>
 
-    <!-- Main content area -->
-    <div class="flex-1">
-      <div id="day-content" class="max-w-7xl mx-auto p-6">
-        <div class="flex flex-col md:flex-row md:space-x-8">
-          <!-- Left column: Content -->
-          <div class="flex-1 px-8">
-            <!-- Title and info -->
-            <div class="mb-8">
-              <h2 id="day-title" class="text-4xl font-bold mb-6 text-blue-800"></h2>
+      <!-- Main content area -->
+      <div class="flex-1">
+        <div id="day-content" class="max-w-7xl mx-auto p-6">
+          <div class="flex flex-col md:flex-row md:space-x-8">
+            <!-- Left column: Content -->
+            <div class="flex-1 px-8">
+              <!-- Title and info -->
+              <div class="mb-8">
+                <h2 id="day-title" class="text-4xl font-bold mb-6 text-blue-800"></h2>
 
-              <!-- Travel info icons -->
-              <div class="inline-flex items-center gap-8 px-6 py-4 bg-blue-50 rounded-lg mb-8">
-                <div class="flex items-center">
-                  <span class="text-2xl mr-3 text-blue-500">⏰</span>
-                  <span id="wake-up" class="text-blue-700"></span>
+                <!-- Travel info icons -->
+                <div class="inline-flex items-center gap-8 px-6 py-4 bg-blue-50 rounded-lg mb-8">
+                  <div class="flex items-center">
+                    <span class="text-2xl mr-3 text-blue-500">⏰</span>
+                    <span id="wake-up" class="text-blue-700"></span>
+                  </div>
+                  <div class="flex items-center">
+                    <span class="text-2xl mr-3 text-blue-500">🏨</span>
+                    <span id="sleep" class="text-blue-700"></span>
+                  </div>
+                  <div class="flex items-center">
+                    <span class="text-2xl mr-3 text-blue-500">🚗</span>
+                    <span id="distance" class="text-blue-700"></span>
+                  </div>
                 </div>
-                <div class="flex items-center">
-                  <span class="text-2xl mr-3 text-blue-500">🏨</span>
-                  <span id="sleep" class="text-blue-700"></span>
-                </div>
-                <div class="flex items-center">
-                  <span class="text-2xl mr-3 text-blue-500">🚗</span>
-                  <span id="distance" class="text-blue-700"></span>
-                </div>
-              </div>
 
-              <!-- Activities -->
-              <div class="prose max-w-none">
-                <div id="activities-list" class="space-y-6 pl-8">
-                  <!-- Activities will be inserted here -->
+                <!-- Activities -->
+                <div class="prose max-w-none">
+                  <div id="activities-list" class="space-y-6 pl-8">
+                    <!-- Activities will be inserted here -->
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
 
-          <!-- Right column: Photo -->
-          <div class="md:w-1/3 md:sticky md:top-24">
-            <div id="photos-grid" class="sticky top-24">
-              <!-- Photos will be inserted here -->
+            <!-- Right column: Photo -->
+            <div class="md:w-1/3 md:sticky md:top-24">
+              <div id="photos-grid" class="sticky top-24">
+                <!-- Photos will be inserted here -->
+              </div>
             </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
-</main>
 
-<!-- Photo lightbox -->
-<div id="lightbox" class="lightbox">
-  <img id="lightbox-img" class="max-h-[90vh] max-w-[90vw] object-contain" src="" alt="">
-  <button class="absolute top-4 right-4 text-white text-4xl" onclick="closeLightbox()">&times;</button>
-</div>
+    <!-- Photo lightbox -->
+    <div id="lightbox" class="lightbox">
+      <img id="lightbox-img" class="max-h-[90vh] max-w-[90vw] object-contain" src="" alt="">
+      <button class="absolute top-4 right-4 text-white text-4xl" onclick="closeLightbox()">&times;</button>
+    </div>
+  </section>
+
+  <section id="infos"></section>
 
 
   <footer class="bg-gray-800 text-white text-center p-4">


### PR DESCRIPTION
## Summary
- Add top navigation with links to new sections.
- Include additional stylesheet `roadtrip.css`.
- Introduce sections for accueil, itinerary, programme, and infos.

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6893d57652e08320b4c6eeb31aa49456