### PR TITLE
Add hero section CSS styling with correct image path

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,0 +1,26 @@
+.hero {
+  position: relative;
+  height: 100vh;
+  background: url('../../caro_flo_roadtrip_cover.jpg') center/cover no-repeat;
+}
+.hero::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: rgba(0,0,0,0.4);
+}
+
+.hero-text {
+  position: relative;
+  z-index: 1;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  text-align: center;
+  padding: 0 1rem;
+}
+.hero-text h1 { font-size: clamp(2rem, 5vw, 4rem); }
+.hero-text p  { margin-top: 1rem; font-size: clamp(1rem, 2.5vw, 1.5rem); }


### PR DESCRIPTION
## Summary
- Add hero section with full-height background and overlay
- Style hero text with responsive typography and center alignment
- Reference background image using correct relative path

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6894700ee1ac8320af7873eb498c23de