### PR TITLE
Add itinerary rendering script

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,0 +1,40 @@
+fetch('itinerary.json')
+  .then(r => r.json())
+  .then(days => {
+    const container = document.getElementById('programme');
+    days.forEach(d => {
+      const block = document.createElement('div');
+      block.className = 'day-block';
+
+      const title = document.createElement('h3');
+      title.textContent = d.jour || `Jour ${d.day}`;
+      block.appendChild(title);
+
+      if (d.travel && d.travel.trim() !== '' && d.travel.toLowerCase() !== 'aucun') {
+        const trip = document.createElement('p');
+        trip.textContent = d.travel;
+        block.appendChild(trip);
+      }
+
+      const agenda = document.createElement('ul');
+      d.agenda.forEach(item => {
+        const li = document.createElement('li');
+        li.textContent = item;
+        agenda.appendChild(li);
+      });
+      block.appendChild(agenda);
+
+      const desc = document.createElement('p');
+      desc.textContent = d.explication;
+      block.appendChild(desc);
+
+      const img = document.createElement('img');
+      img.src = `jour${d.day}.jpg`;
+      img.alt = d.photo || title.textContent;
+      img.onerror = () => { img.src = `jour${d.day}.png`; };
+      block.appendChild(img);
+
+      container.appendChild(block);
+    });
+  })
+  .catch(err => console.error('Erreur de chargement du programme', err));


### PR DESCRIPTION
## Summary
- add front-end script to render itinerary program dynamically from itinerary.json

## Testing
- `npm test` (fails: Could not read package.json)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689478995b888320a8da692d4f8e3e6c