### PR TITLE
Add responsive day block styling

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -24,3 +24,26 @@
 }
 .hero-text h1 { font-size: clamp(2rem, 5vw, 4rem); }
 .hero-text p  { margin-top: 1rem; font-size: clamp(1rem, 2.5vw, 1.5rem); }
+
+.day-block {
+  margin: 2rem auto;
+  padding: 1.5rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+  max-width: 800px;
+  background: #fff;
+}
+
+.day-block img {
+  width: 100%;
+  height: auto;
+  margin-top: 1rem;
+  border-radius: 0.5rem;
+}
+
+@media (max-width: 640px) {
+  .day-block {
+    margin: 1rem;
+    padding: 1rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add `.day-block` styling for layout, image handling and responsive spacing

## Testing
- `python -m py_compile build.py server.py`


------
https://chatgpt.com/codex/tasks/task_e_68947ac61dd0832089677fe6d47c993e