### PR TITLE
Add key figures to itinerary section

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,8 +39,19 @@
   </section>
 
   <section id="itineraire" class="h-[400px] relative z-0">
-    <!-- carte interactive -->
-    <div id="map-container" class="w-full h-full"></div>
+    <div class="chiffres-cles">
+      <ul>
+        <li>📅 Durée : 16 jours</li>
+        <li>🚗 Distance : ~3 500 km</li>
+        <li>🏞️ Parcs visités : 10</li>
+        <li>🏙️ Villes étapes : 6 grandes villes</li>
+        <li>📷 Lieux iconiques : plus de 30</li>
+        <li>📍 États traversés : 3 (Californie, Nevada, Arizona)</li>
+      </ul>
+    </div>
+    <div class="carte">
+      <div id="map-container" class="w-full h-full"></div>
+    </div>
   </section>
 
   <section id="programme">


### PR DESCRIPTION
## Summary
- display itinerary key figures alongside map
- retain existing map container for initialization

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_68947e74cb608320a1eddcc7ae1e4edf