### PR TITLE
Add responsive grid and map styles

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -47,3 +47,34 @@
     padding: 1rem;
   }
 }
+
+.chiffres-cles {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+}
+
+.chiffres-cles div {
+  background: #f9fafb;
+  padding: 1.5rem;
+  text-align: center;
+  font-size: 2.5rem;
+}
+
+.carte {
+  width: 100%;
+  height: auto;
+  max-height: 400px;
+  object-fit: cover;
+  display: block;
+  margin: 0 auto;
+}
+
+@media (max-width: 640px) {
+  .chiffres-cles {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  .carte {
+    max-height: 300px;
+  }
+}


### PR DESCRIPTION
## Summary
- introduce a responsive `.chiffres-cles` grid with desktop and mobile layouts
- style `.chiffres-cles div` entries with centered content and large emoji-friendly font sizing
- add responsive `.carte` sizing for fluid width and height constraints

## Testing
- `pytest`
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68947f5576108320bd24daf621ca6531