### PR TITLE
Add card and fade-in styling for day blocks

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -25,26 +25,66 @@
 .hero-text h1 { font-size: clamp(2rem, 5vw, 4rem); }
 .hero-text p  { margin-top: 1rem; font-size: clamp(1rem, 2.5vw, 1.5rem); }
 
-.day-block {
-  margin: 2rem auto;
-  padding: 1.5rem;
+.card {
+  background: #fff;
   border: 1px solid #e5e7eb;
   border-radius: 0.5rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.fade-in {
+  opacity: 0;
+  animation: fadeIn 0.6s ease forwards;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.day-block {
+  margin: 2rem auto;
   max-width: 800px;
   background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  padding: 1.5rem;
+  animation: fadeIn 0.6s ease forwards;
+}
+
+.day-block h3 {
+  color: #2c3e50;
+  font-size: 1.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.day-block p {
+  line-height: 1.6;
+  margin: 0.75rem 0;
 }
 
 .day-block img {
-  width: 100%;
+  max-width: 100%;
   height: auto;
   margin-top: 1rem;
   border-radius: 0.5rem;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
 }
 
 @media (max-width: 640px) {
   .day-block {
-    margin: 1rem;
+    margin: 1rem 0;
     padding: 1rem;
+    max-width: 100%;
   }
 }
 


### PR DESCRIPTION
## Summary
- add reusable `.card` class with light background, rounded edges, shadow, and spacing
- introduce `.fade-in` animation and keyframes for smooth block appearance
- enhance `.day-block` styling, typography, images, and mobile layout

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68948140e0308320b020c095f1ea00b2