### PR TITLE
Add breadcrumb text for each day

### DIFF
--- a/script.js
+++ b/script.js
@@ -6,6 +6,12 @@ fetch('itinerary.json')
       const block = document.createElement('div');
       block.className = 'day-block';
 
+      const filArianeText = `Jour ${d.day} sur 16 – ${d.name}`;
+      const filAriane = document.createElement('p');
+      filAriane.className = 'fil-ariane';
+      filAriane.textContent = filArianeText;
+      block.appendChild(filAriane);
+
       const title = document.createElement('h3');
       title.textContent = d.jour || `Jour ${d.day}`;
       block.appendChild(title);


### PR DESCRIPTION
## Summary
- compute breadcrumb text `Jour X sur 16 – <day name>` for each day
- insert `fil-ariane` paragraph before day heading

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68948306e4bc8320af5b209d20fa851b