### PR TITLE
Add breadcrumb styling with fade-in effect

### DIFF
--- a/script.js
+++ b/script.js
@@ -35,6 +35,10 @@ fetch('itinerary.json')
       block.appendChild(img);
 
       container.appendChild(block);
+
+      block.querySelectorAll('.fil-ariane').forEach(el => {
+        requestAnimationFrame(() => el.classList.add('loaded'));
+      });
     });
   })
   .catch(err => console.error('Erreur de chargement du programme', err));

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -72,6 +72,18 @@
   margin: 0.75rem 0;
 }
 
+.fil-ariane {
+  color: #6b7280;
+  font-style: italic;
+  margin-bottom: 0.5rem;
+  opacity: 0;
+  transition: opacity 0.6s ease;
+}
+
+.fil-ariane.loaded {
+  opacity: 1;
+}
+
 .day-block img {
   max-width: 100%;
   height: auto;


### PR DESCRIPTION
## Summary
- style breadcrumb `.fil-ariane` in soft gray with spacing and fade-in animation
- trigger breadcrumb fade-in via JS once inserted into the DOM

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68948322d2848320bae271407a953b20