### PR TITLE
Ensure itinerary map fills section height

### DIFF
--- a/roadtrip_usa_2026.html
+++ b/roadtrip_usa_2026.html
@@ -25,7 +25,7 @@
   </header>
 
   <section id="accueil"></section>
-  <section id="itineraire"></section>
+  <section id="itineraire" class="h-[400px]"></section>
 
   <section id="programme">
     <main>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -113,11 +113,10 @@
   font-size: 2.5rem;
 }
 
+/*. Map container */
 .carte {
   width: 100%;
-  height: auto;
-  max-height: 400px;
-  object-fit: cover;
+  height: 100%;
   display: block;
   margin: 0 auto;
 }
@@ -125,8 +124,5 @@
 @media (max-width: 640px) {
   .chiffres-cles {
     grid-template-columns: repeat(2, 1fr);
-  }
-  .carte {
-    max-height: 300px;
   }
 }


### PR DESCRIPTION
## Summary
- Treat `.carte` as a container by removing image-specific styles and letting it fill available height
- Explicitly size the itinerary section to 400px so embedded map can expand

## Testing
- `python -m pytest`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68948c62bf28832083036fab83494845