### PR TITLE
style: add programme section layout and responsive sidebar

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -126,3 +126,73 @@
     grid-template-columns: repeat(2, 1fr);
   }
 }
+
+/* Programme section layout */
+#programme {
+  display: flex;
+  gap: 1rem;
+}
+
+#sidebar-programme {
+  width: 220px;
+  overflow-y: auto;
+  background: #f3f4f6;
+  padding: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+#sidebar-programme button {
+  padding: 0.5rem 0.75rem;
+  background: transparent;
+  border: 1px solid transparent;
+  text-align: left;
+  cursor: pointer;
+  border-radius: 0.375rem;
+  transition: background 0.3s, border 0.3s;
+}
+
+#sidebar-programme button:hover {
+  background: #e5e7eb;
+}
+
+#sidebar-programme button.selected {
+  background: #3b82f6;
+  color: #fff;
+}
+
+#jour-detail {
+  flex-grow: 1;
+  background: #fff;
+  padding: 1rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  overflow-y: auto;
+}
+
+#jour-detail img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 0.5rem;
+}
+
+#jour-detail ul {
+  margin: 0.75rem 0 0 1.25rem;
+  list-style: disc;
+}
+
+@media (max-width: 768px) {
+  #programme {
+    flex-direction: column;
+  }
+  #sidebar-programme {
+    width: 100%;
+    flex-direction: row;
+    overflow-x: auto;
+    overflow-y: hidden;
+    white-space: nowrap;
+  }
+  #sidebar-programme button {
+    flex: 0 0 auto;
+  }
+}


### PR DESCRIPTION
## Summary
- style programme section using flex layout with a scrollable sidebar and responsive detail area
- add hover and selection styles for sidebar buttons and responsive adjustments for mobile

## Testing
- `python -m py_compile build.py server.py`


------
https://chatgpt.com/codex/tasks/task_e_68949558ade88320af6ae1afa1f38242