### PR TITLE
Toggle selected day highlighting

### DIFF
--- a/script.js
+++ b/script.js
@@ -5,10 +5,13 @@ fetch('itinerary.json')
     const detailContainer = document.getElementById('jour-detail');
 
     function showDay(day, button) {
-      sidebar.querySelectorAll('button').forEach(btn => btn.classList.remove('selected'));
-      button.classList.add('selected');
+      sidebar.querySelectorAll('button').forEach(btn => {
+        if (btn !== button) btn.classList.remove('selected');
+      });
+      const isSelected = button.classList.toggle('selected');
 
       detailContainer.innerHTML = '';
+      if (!isSelected) return;
       const block = document.createElement('div');
       block.classList.add('day-block', 'fade-in');
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -157,9 +157,10 @@
   background: #e5e7eb;
 }
 
-#sidebar-programme button.selected {
+.selected {
   background: #3b82f6;
   color: #fff;
+  font-weight: bold;
 }
 
 #jour-detail {


### PR DESCRIPTION
## Summary
- Toggle the `.selected` class on day buttons to allow deselection and clear the detail view when clicked again.
- Style `.selected` elements with a bold font and blue background so the active day stands out.

## Testing
- `node --check script.js`
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_68949663e06c8320acda941eea6d6882