### PR TITLE
Trigger fade-in when switching days

### DIFF
--- a/script.js
+++ b/script.js
@@ -13,7 +13,7 @@ fetch('itinerary.json')
       detailContainer.innerHTML = '';
       if (!isSelected) return;
       const block = document.createElement('div');
-      block.classList.add('day-block', 'fade-in');
+      block.classList.add('day-block');
 
       const title = document.createElement('h3');
       title.textContent = day.jour || `Jour ${day.day}`;
@@ -44,6 +44,10 @@ fetch('itinerary.json')
       block.appendChild(img);
 
       detailContainer.appendChild(block);
+      detailContainer.classList.add('fade-in');
+      detailContainer.addEventListener('animationend', () => {
+        detailContainer.classList.remove('fade-in');
+      }, { once: true });
     }
 
     days.forEach(d => {


### PR DESCRIPTION
## Summary
- Fade in the day detail container after content injection.
- Remove fade-in class when the animation ends so it can re-run on subsequent day selections.

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894976b53288320a1c300fda323ac55