### PR TITLE
Adjust itinerary section layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
     </div>
   </section>
 
-  <section id="itineraire" class="h-[400px] relative z-0">
+  <section id="itineraire" class="min-h-[400px] relative z-0 pb-8">
     <div class="chiffres-cles">
       <ul>
         <li>📅 Durée : 16 jours</li>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -121,6 +121,10 @@
   margin: 0 auto;
 }
 
+#itineraire {
+  overflow: hidden;
+}
+
 @media (max-width: 640px) {
   .chiffres-cles {
     grid-template-columns: repeat(2, 1fr);
@@ -131,6 +135,7 @@
 #programme {
   display: flex;
   gap: 1rem;
+  margin-top: 2rem;
 }
 
 #sidebar-programme {


### PR DESCRIPTION
## Summary
- Use `min-h-[400px]` and `pb-8` on itinerary section for flexible height and spacing
- Confine itinerary map overflow and separate programme section with top margin

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68949cdd165c83209985b8d9a65502c1