### PR TITLE
Add poetic day names before itinerary details

### DIFF
--- a/script.js
+++ b/script.js
@@ -19,6 +19,13 @@ fetch('itinerary.json')
       title.textContent = day.jour || `Jour ${day.day}`;
       block.appendChild(title);
 
+      if (day.name) {
+        const poetic = document.createElement('h3');
+        poetic.classList.add('jour-title');
+        poetic.textContent = day.name;
+        block.appendChild(poetic);
+      }
+
       if (day.travel && day.travel.trim() !== '' && day.travel.toLowerCase() !== 'aucun') {
         const trip = document.createElement('p');
         trip.textContent = day.travel;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -67,6 +67,11 @@
   margin-bottom: 0.75rem;
 }
 
+.jour-title {
+  margin-top: 0.25rem;
+  font-style: italic;
+}
+
 .day-block p {
   line-height: 1.6;
   margin: 0.75rem 0;


### PR DESCRIPTION
## Summary
- show optional poetic day titles after the main day title
- style poetic day titles with a subtle italic margin

## Testing
- `npm test` *(fails: no package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68949e75687883209785fd8df1795d93