### PR TITLE
Fix navigation container selector

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -123,7 +123,7 @@ async function loadTripData() {
 
 // Render navigation
 function renderNavigation(data) {
-  const nav = document.getElementById('days-nav');
+  const nav = document.getElementById('sidebar-programme');
   nav.innerHTML = data.map(day => `
     <button
       class="day-button ${currentDay === day.day ? 'active' : ''}"


### PR DESCRIPTION
## Summary
- target the existing `sidebar-programme` element when rendering day navigation

## Testing
- `node --check static/js/app.js`
- `python server.py` & `curl -I http://localhost:8000/index.html`


------
https://chatgpt.com/codex/tasks/task_e_6894a48427348320bdeb8121d619a35e