### PR TITLE
Ensure map wrapper enforces minimum height

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -123,6 +123,7 @@
   width: 100%;
   display: block;
   margin: 0 auto;
+  min-height: 400px;
 }
 
 /* Leaflet map element */
@@ -140,6 +141,9 @@
 @media (max-width: 640px) {
   .chiffres-cles {
     grid-template-columns: repeat(2, 1fr);
+  }
+  .carte {
+    min-height: 300px;
   }
   .map-container {
     min-height: 300px;


### PR DESCRIPTION
## Summary
- Set `.carte` to a minimum height of 400px for consistent map rendering
- Apply a 300px minimum height to `.carte` on small screens

## Testing
- `pytest`
- `python - <<'PY'
from html.parser import HTMLParser

class MyParser(HTMLParser):
    def __init__(self):
        super().__init__()
        self.stack=[]
        self.found=False
    def handle_starttag(self, tag, attrs):
        attrs=dict(attrs)
        self.stack.append((tag, attrs))
        if tag=='div' and attrs.get('class')=='carte':
            if any(p_attrs.get('id')=='itineraire' for _,p_attrs in self.stack[:-1]):
                self.found=True
    def handle_endtag(self, tag):
        if self.stack and self.stack[-1][0]==tag:
            self.stack.pop()

parser=MyParser()
parser.feed(open('index.html').read())
print('carte inside itineraire:', parser.found)
PY`

------
https://chatgpt.com/codex/tasks/task_e_6894ae76a368832088133d83e1ce29cd