### PR TITLE
feat: modernize site typography and add highlight utility

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,3 +1,19 @@
+@import url('https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&family=Open+Sans:wght@400;700&display=swap');
+
+/* Global typography */
+body, p, nav, nav a, footer, ul, li, figcaption, small, span {
+  font-family: 'Open Sans', sans-serif;
+}
+
+h1, h2, h3, blockquote {
+  font-family: 'Playfair Display', serif;
+}
+
+.highlight {
+  font-weight: bold;
+  color: #d97706;
+}
+
 .hero {
   position: relative;
   height: 100vh;


### PR DESCRIPTION
## Summary
- import Google Fonts for serif and sans-serif families
- apply Open Sans to body text and Playfair Display to headings
- add `.highlight` class for emphasized text

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/Voyage-USA/package.json')*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894b160934c832094bf277221dcb6fa