### PR TITLE
style: replace paper texture with gradient

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -77,6 +77,20 @@ h1, h2, h3, blockquote {
   animation: fadeIn 0.6s ease forwards;
 }
 
+.carnet .day-block {
+  background: #fdf6e3;
+  background-image: repeating-linear-gradient(
+    0deg,
+    rgba(0, 0, 0, 0.02) 0,
+    rgba(0, 0, 0, 0.02) 1px,
+    transparent 1px,
+    transparent 8px
+  );
+  border: 1px solid #e0d7c3;
+  border-radius: 12px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+}
+
 .day-block h3 {
   color: #2c3e50;
   font-size: 1.75rem;


### PR DESCRIPTION
## Summary
- use CSS gradient to mimic paper texture for `.carnet .day-block`
- drop unused paper-texture.png asset

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894c1d053e88320918c5fb1eed9e7d3