### PR TITLE
style: add rotation and border to day-block images

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -134,7 +134,13 @@ h1, h2, h3, blockquote {
   height: auto;
   margin-top: 1rem;
   border-radius: 0.5rem;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  border: 4px solid #fff;
+  box-shadow: 2px 6px 10px rgba(0,0,0,0.15);
+  transform: rotate(-2deg);
+}
+
+.day-block img:nth-of-type(even) {
+  transform: rotate(2deg);
 }
 
 @media (max-width: 640px) {


### PR DESCRIPTION
## Summary
- Add white border and stronger shadow to `.day-block` images
- Slightly rotate images and alternate rotation for even images

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/Voyage-USA/package.json')*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894c4542cf48320abd3f247a920ed38