### PR TITLE
Use slide-fade animation for day blocks

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -66,6 +66,17 @@ h1, h2, h3, blockquote {
   }
 }
 
+@keyframes slideFadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 .day-block {
   margin: 2rem auto;
   max-width: 800px;
@@ -74,7 +85,7 @@ h1, h2, h3, blockquote {
   border-radius: 0.5rem;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   padding: 1.5rem;
-  animation: fadeIn 0.6s ease forwards;
+  animation: slideFadeIn 0.8s ease forwards;
 }
 
 .carnet .day-block {


### PR DESCRIPTION
## Summary
- add `slideFadeIn` keyframes for sliding fade animation
- apply `slideFadeIn` to `.day-block` elements with longer duration

## Testing
- `python build.py`


------
https://chatgpt.com/codex/tasks/task_e_6894c6865cec8320ab2814e78180b365