### PR TITLE
Stack key stats grid on small screens

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -206,9 +206,9 @@ h1, h2, h3, blockquote {
   }
 }
 
-@media (max-width: 480px) {
+@media (max-width: 640px) {
   .chiffres-cles {
-    grid-template-columns: 1fr;
+    grid-template-columns: repeat(1, 1fr);
   }
 }
 


### PR DESCRIPTION
## Summary
- Stack key stats in a single column below 640px for better mobile readability

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689614d226408320b73fc5f5f9662162