### PR TITLE
Add itinerary day-by-day heading

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,6 +87,7 @@
       </div>
     </div>
     <!-- Carte interactive chargée depuis static/js/app.js et circuit-voyage-usa.kml -->
+    <h3 class="text-center text-2xl font-semibold mb-4">Notre parcours jour par jour</h3>
     <div class="carte">
       <div id="map-container" class="map-container w-full"></div>
     </div>


### PR DESCRIPTION
## Summary
- Add a heading introducing the day-by-day itinerary before the map section in `index.html`

## Testing
- `python -m py_compile server.py build.py`


------
https://chatgpt.com/codex/tasks/task_e_6896177877008320a517462ae5837e07