### PR TITLE
style: add padding and border to itinerary section

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -193,6 +193,9 @@ h1, h2, h3, blockquote {
 
 #itineraire {
   overflow: hidden;
+  padding-top: 3rem;
+  border-top: 1px solid #e5e7eb;
+  background: #f0f9ff;
 }
 
 .itineraire-intro {


### PR DESCRIPTION
## Summary
- give the itinerary section more breathing room and a top divider
- add soft background styling

## Testing
- `python -m pytest`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689618cb79508320896f95020c3d1c5d