### PR TITLE
Refactor itinerary map and key figures layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,60 +38,63 @@
     </div>
   </section>
 
-  <section id="itineraire" class="min-h-[400px] relative z-0 pb-8">
-    <p class="itineraire-intro text-center italic mb-6">
-      À chaque route un souvenir, laissez l'horizon guider votre aventure.
-    </p>
-    <div class="chiffres-cles grid">
-      <div class="stat-item flex gap-4 items-center">
-        <span>📅</span>
-        <div>
-          <strong class="text-blue-600">16&nbsp;jours</strong>
-          <span class="text-sm text-gray-600">Durée</span>
+    <section id="itineraire" class="min-h-[400px] relative z-0 pb-8">
+      <h2 class="text-center text-3xl font-bold mb-4">Notre aventure de 16 jours à travers l’Ouest américain</h2>
+      <p class="itineraire-intro text-center italic mb-6">
+        À chaque route un souvenir, laissez l'horizon guider votre aventure.
+      </p>
+      <div class="itineraire-wrapper">
+        <div class="map-zone flex-1">
+          <h3 class="text-center text-2xl font-semibold mb-4">Notre parcours jour par jour</h3>
+          <!-- Carte interactive chargée depuis static/js/app.js et circuit-voyage-usa.kml -->
+          <div id="map-container" class="map-container w-full"></div>
+        </div>
+        <div class="chiffres-cles">
+          <div class="stat-item">
+            <span class="icon">📅</span>
+            <div class="stat-info">
+              <span class="stat-value">16&nbsp;jours</span>
+              <span class="stat-label">Durée</span>
+            </div>
+          </div>
+          <div class="stat-item">
+            <span class="icon">🚗</span>
+            <div class="stat-info">
+              <span class="stat-value">~3&nbsp;500&nbsp;km</span>
+              <span class="stat-label">Distance</span>
+            </div>
+          </div>
+          <div class="stat-item">
+            <span class="icon">🏞️</span>
+            <div class="stat-info">
+              <span class="stat-value">10</span>
+              <span class="stat-label">Parcs visités</span>
+            </div>
+          </div>
+          <div class="stat-item">
+            <span class="icon">🏙️</span>
+            <div class="stat-info">
+              <span class="stat-value">6</span>
+              <span class="stat-label">Villes étapes</span>
+            </div>
+          </div>
+          <div class="stat-item">
+            <span class="icon">📷</span>
+            <div class="stat-info">
+              <span class="stat-value">30+</span>
+              <span class="stat-label">Lieux iconiques</span>
+            </div>
+          </div>
+          <div class="stat-item">
+            <span class="icon">📍</span>
+            <div class="stat-info">
+              <span class="stat-value">3</span>
+              <span class="stat-label">États traversés</span>
+            </div>
+          </div>
         </div>
       </div>
-      <div class="stat-item flex gap-4 items-center">
-        <span>🚗</span>
-        <div>
-          <strong class="text-blue-600">~3&nbsp;500&nbsp;km</strong>
-          <span class="text-sm text-gray-600">Distance</span>
-        </div>
-      </div>
-      <div class="stat-item flex gap-4 items-center">
-        <span>🏞️</span>
-        <div>
-          <strong class="text-blue-600">10</strong>
-          <span class="text-sm text-gray-600">Parcs visités</span>
-        </div>
-      </div>
-      <div class="stat-item flex gap-4 items-center">
-        <span>🏙️</span>
-        <div>
-          <strong class="text-blue-600">6</strong>
-          <span class="text-sm text-gray-600">Villes étapes</span>
-        </div>
-      </div>
-      <div class="stat-item flex gap-4 items-center">
-        <span>📷</span>
-        <div>
-          <strong class="text-blue-600">30+</strong>
-          <span class="text-sm text-gray-600">Lieux iconiques</span>
-        </div>
-      </div>
-      <div class="stat-item flex gap-4 items-center">
-        <span>📍</span>
-        <div>
-          <strong class="text-blue-600">3</strong>
-          <span class="text-sm text-gray-600">États traversés</span>
-        </div>
-      </div>
-    </div>
-    <!-- Carte interactive chargée depuis static/js/app.js et circuit-voyage-usa.kml -->
-    <h3 class="text-center text-2xl font-semibold mb-4">Notre parcours jour par jour</h3>
-    <div class="carte">
-      <div id="map-container" class="map-container w-full"></div>
-    </div>
-  </section>
+    </section>
 
   <section id="programme">
     <div id="sidebar-programme"></div>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -162,25 +162,60 @@ h1, h2, h3, blockquote {
   }
 }
 
-.chiffres-cles {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 1rem;
+
+.itineraire-wrapper {
+  display: flex;
+  gap: 2rem;
+  align-items: flex-start;
+  margin-bottom: 2rem;
 }
 
-.stat-item {
+.map-zone {
+  flex: 2;
+}
+
+.chiffres-cles {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  background: #fff;
   padding: 1rem;
-  background: #f9fafb;
   border-radius: 0.5rem;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
 }
 
-/* Map wrapper */
-.carte {
-  width: 100%;
+.stat-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.stat-item .stat-info {
+  display: flex;
+  flex-direction: column;
+}
+
+.stat-item .icon {
+  font-size: 1.5rem;
+  color: #2563eb;
+}
+
+.stat-item .stat-value {
+  font-weight: 700;
+  color: #2563eb;
+}
+
+.stat-item .stat-label {
   display: block;
-  margin: 0 auto;
-  min-height: 400px;
+  font-size: 0.875rem;
+  color: #4b5563;
+}
+
+@media (max-width: 768px) {
+  .itineraire-wrapper {
+    flex-direction: column;
+  }
 }
 
 /* Leaflet map element */
@@ -202,23 +237,7 @@ h1, h2, h3, blockquote {
   max-width: 700px;
   margin: 0 auto;
 }
-
-@media (max-width: 768px) {
-  .chiffres-cles {
-    grid-template-columns: repeat(2, 1fr);
-  }
-}
-
 @media (max-width: 640px) {
-  .chiffres-cles {
-    grid-template-columns: repeat(1, 1fr);
-  }
-}
-
-@media (max-width: 640px) {
-  .carte {
-    min-height: 300px;
-  }
   .map-container {
     min-height: 300px;
   }


### PR DESCRIPTION
## Summary
- Wrap itinerary map and stats in new flex-based `.itineraire-wrapper`
- Add section title and rework key figures with icons, values, and labels
- Style wrapper and stats for responsive column layout with colored icons

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6896525b1e34832089fbebe1c140455c