### PR TITLE
feat: add structured day layout

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -154,6 +154,45 @@ h1, h2, h3, blockquote {
   transform: rotate(2deg);
 }
 
+.day-content {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.day-content .left,
+.day-content .right {
+  flex: 1;
+}
+
+.day-content .travel-icons {
+  display: flex;
+  gap: 0.5rem;
+  font-size: 1.2rem;
+  margin: 0.5rem 0;
+}
+
+@media (min-width: 768px) {
+  .day-content {
+    flex-direction: row;
+  }
+  .day-content .left {
+    flex: 0 0 70%;
+  }
+  .day-content .right {
+    flex: 0 0 30%;
+  }
+}
+
+.day-content .jour-image {
+  max-width: 100%;
+  height: auto;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+  transform: none;
+}
+
 @media (max-width: 640px) {
   .day-block {
     margin: 1rem 0;

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -177,24 +177,51 @@ function showDay(dayNumber, button) {
     if (!isSelected) return;
 
     const block = document.createElement('div');
-    block.classList.add('day-block');
+    block.classList.add('day-block', 'day-content');
+
+    const leftCol = document.createElement('div');
+    leftCol.classList.add('left');
+    const rightCol = document.createElement('div');
+    rightCol.classList.add('right');
 
     const title = document.createElement('h3');
     title.textContent = day.jour || `Jour ${day.day}`;
-    block.appendChild(title);
+    leftCol.appendChild(title);
 
     if (day.name) {
       const poetic = document.createElement('h3');
       poetic.classList.add('jour-title');
       poetic.textContent = day.name;
-      block.appendChild(poetic);
+      leftCol.appendChild(poetic);
     }
 
-    if (day.travel && day.travel.trim() !== '' && day.travel.toLowerCase() !== 'aucun') {
-      const trip = document.createElement('p');
-      trip.textContent = day.travel;
-      block.appendChild(trip);
+    if (Array.isArray(day.activities) && day.activities.length > 0) {
+      const travelIcons = document.createElement('div');
+      travelIcons.classList.add('travel-icons');
+      day.activities.forEach(act => {
+        const span = document.createElement('span');
+        span.textContent = act.icon;
+        span.title = act.label;
+        travelIcons.appendChild(span);
+      });
+      leftCol.appendChild(travelIcons);
     }
+
+    const steps = document.createElement('p');
+    const stepParts = [];
+    if (day.wake) stepParts.push(day.wake);
+    if (day.sleep) stepParts.push(day.sleep);
+    if (stepParts.length > 0) {
+      steps.textContent = stepParts.join(' → ');
+      if (day.travel && day.travel.trim() !== '' && day.travel.toLowerCase() !== 'aucun') {
+        steps.textContent += ` (${day.travel})`;
+      }
+      leftCol.appendChild(steps);
+    }
+
+    const desc = document.createElement('p');
+    desc.textContent = day.explication || '';
+    leftCol.appendChild(desc);
 
     const agenda = document.createElement('ul');
     (day.agenda || []).forEach(item => {
@@ -202,17 +229,21 @@ function showDay(dayNumber, button) {
       li.textContent = item;
       agenda.appendChild(li);
     });
-    block.appendChild(agenda);
-
-    const desc = document.createElement('p');
-    desc.textContent = day.explication || '';
-    block.appendChild(desc);
+    leftCol.appendChild(agenda);
 
     const img = document.createElement('img');
+    img.classList.add('jour-image');
     img.src = `jour${day.day}.jpg`;
     img.alt = day.photo || title.textContent;
     img.onerror = () => { img.src = `jour${day.day}.png`; };
-    block.appendChild(img);
+    rightCol.appendChild(img);
+
+    const miniMap = document.createElement('div');
+    miniMap.classList.add('mini-map');
+    rightCol.appendChild(miniMap);
+
+    block.appendChild(leftCol);
+    block.appendChild(rightCol);
 
     detailContainer.appendChild(block);
     detailContainer.classList.add('fade-in');


### PR DESCRIPTION
## Summary
- Structure daily view into left/right columns with travel icons, agenda and image/map areas
- Style new day-content layout with responsive 70/30 grid and polished images

## Testing
- `node --check static/js/app.js`
- `python -m py_compile server.py build.py`


------
https://chatgpt.com/codex/tasks/task_e_6896575011508320b0db34dcf4f706be