### PR TITLE
feat: add mini maps for daily itineraries

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -154,6 +154,15 @@ h1, h2, h3, blockquote {
   transform: rotate(2deg);
 }
 
+.mini-map {
+  width: 250px;
+  height: 250px;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  margin-top: 1rem;
+}
+
 .day-content {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- initialize and clean up Leaflet mini maps for each day
- show compact OpenStreetMap tiles with markers for daily steps
- add styling for the mini-map container

## Testing
- `python -m py_compile build.py server.py`


------
https://chatgpt.com/codex/tasks/task_e_689658e6bec483208ce929ee5bb5ff38