### PR TITLE
feat: highlight active day

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -328,10 +328,11 @@ h1, h2, h3, blockquote {
 }
 
 .selected {
-  background: #dbeafe;
-  color: #1e3a8a;
+  background: #2563eb;
+  color: #fff;
   font-weight: bold;
   border-color: #3b82f6;
+  border-left: 4px solid #1e3a8a;
 }
 
 #jour-detail {

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -74,10 +74,6 @@ async function initMap() {
           });
           marker.openTooltip();
           showDay(entry.days[0]);
-          const navBtn = document.querySelector(`.day-button[data-day="${entry.days[0]}"]`);
-          if (navBtn) {
-            navBtn.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-          }
         });
       }
     });
@@ -167,21 +163,14 @@ function showDay(dayNumber, button) {
       mini.remove();
       mini = null;
     }
-
-    sidebar.querySelectorAll('button').forEach(btn => {
-      if (btn !== button) btn.classList.remove('selected');
-    });
-
-    let isSelected = true;
-    if (button) {
-      isSelected = button.classList.toggle('selected');
-    } else {
-      const navBtn = sidebar.querySelector(`button[data-day="${dayNum}"]`);
-      if (navBtn) navBtn.classList.add('selected');
+    sidebar.querySelectorAll('button').forEach(btn => btn.classList.remove('selected'));
+    const targetBtn = button || sidebar.querySelector(`button[data-day="${dayNum}"]`);
+    if (targetBtn) {
+      targetBtn.classList.add('selected');
+      targetBtn.scrollIntoView({ behavior: 'smooth', block: 'center' });
     }
 
     detailContainer.innerHTML = '';
-    if (!isSelected) return;
 
     const block = document.createElement('div');
     block.classList.add('day-block', 'day-content');


### PR DESCRIPTION
## Summary
- improve selected day styling with high-contrast color and left border indicator
- ensure navigation highlights only one active day and centers it on selection

## Testing
- `node --check static/js/app.js`
- `python -m py_compile server.py build.py`


------
https://chatgpt.com/codex/tasks/task_e_68965a94df90832095446b018e62ba3b