### PR TITLE
Improve spacing and responsiveness for itinerary sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
     </div>
   </section>
 
-    <section id="itineraire" class="min-h-[400px] relative z-0 pb-8">
+    <section id="itineraire" class="min-h-[400px] relative z-0 pb-8 mb-8">
       <h2 class="text-center text-3xl font-bold mb-4">Notre aventure de 16 jours à travers l’Ouest américain</h2>
       <p class="itineraire-intro text-center italic mb-6">
         À chaque route un souvenir, laissez l'horizon guider votre aventure.
@@ -96,7 +96,7 @@
       </div>
     </section>
 
-  <section id="programme">
+  <section id="programme" class="py-8 mb-8">
     <div id="sidebar-programme"></div>
     <div id="jour-detail"></div>
   </section>

--- a/roadtrip_usa_2026.html
+++ b/roadtrip_usa_2026.html
@@ -25,9 +25,9 @@
   </header>
 
   <section id="accueil"></section>
-  <section id="itineraire" class="h-[400px]"></section>
+  <section id="itineraire" class="h-[400px] mb-8"></section>
 
-  <section id="programme">
+  <section id="programme" class="py-8 mb-8">
     <main>
       <!-- Sidebar -->
       <aside id="side-nav" class="side-nav p-4 hidden md:block">

--- a/static/css/roadtrip.css
+++ b/static/css/roadtrip.css
@@ -11,6 +11,7 @@ main {
   flex: 1;
   display: flex;
   overflow: hidden;
+  gap: 1.5rem;
 }
 #side-nav {
   width: 200px;
@@ -41,10 +42,14 @@ main {
 
 #itineraire {
   background-color: #f0f9ff;
+  padding: 2rem 1rem;
+  margin-bottom: 2rem;
 }
 
 #programme {
   background-color: #fff7ed;
+  padding: 2rem 1rem;
+  margin-bottom: 2rem;
 }
 
 #infos {
@@ -73,5 +78,32 @@ header nav a {
 header nav a:focus,
 header nav a:hover {
   color: #1d4ed8;
+}
+
+@media (max-width: 768px) {
+  main {
+    flex-direction: column;
+  }
+  #side-nav {
+    width: 100%;
+    display: flex;
+    overflow-x: auto;
+    overflow-y: hidden;
+    gap: 0.5rem;
+    padding: 1rem 0;
+  }
+  #content {
+    padding: 1rem;
+  }
+}
+
+@media (max-width: 480px) {
+  #side-nav button {
+    font-size: 0.875rem;
+    padding: 0.5rem;
+  }
+  #content {
+    padding: 0.75rem;
+  }
 }
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -264,6 +264,12 @@ h1, h2, h3, blockquote {
   .itineraire-wrapper {
     flex-direction: column;
   }
+  #itineraire h2 {
+    font-size: 1.75rem;
+  }
+  #itineraire h3 {
+    font-size: 1.25rem;
+  }
 }
 
 /* Leaflet map element */
@@ -276,9 +282,10 @@ h1, h2, h3, blockquote {
 
 #itineraire {
   overflow: hidden;
-  padding-top: 3rem;
+  padding: 3rem 0;
   border-top: 1px solid #e5e7eb;
   background: #f0f9ff;
+  margin-bottom: 3rem;
 }
 
 .itineraire-intro {
@@ -295,8 +302,9 @@ h1, h2, h3, blockquote {
 #programme {
   display: flex;
   align-items: flex-start;
-  gap: 1rem;
-  margin-top: 2rem;
+  gap: 2rem;
+  margin: 2rem 0 3rem;
+  padding: 2rem 0;
 }
 
 #sidebar-programme {
@@ -407,6 +415,12 @@ h1, h2, h3, blockquote {
   .day-block img {
     width: 100%;
     height: auto;
+  }
+  #itineraire h2 {
+    font-size: 1.5rem;
+  }
+  #itineraire h3 {
+    font-size: 1rem;
   }
 }
 


### PR DESCRIPTION
## Summary
- add vertical spacing and responsive typography to `#itineraire` and `#programme`
- tweak roadtrip styles with section padding and mobile-friendly layout
- update itinerary and programme sections in HTML with Tailwind spacing classes

## Testing
- `python -m py_compile server.py build.py`
- `timeout 3 python -u server.py`

------
https://chatgpt.com/codex/tasks/task_e_68965c1901b08320a7cd3beb4af62377