### PR TITLE
Improve mini map responsiveness

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -155,12 +155,13 @@ h1, h2, h3, blockquote {
 }
 
 .mini-map {
-  width: 250px;
-  height: 250px;
+  width: 100%;
+  max-width: 300px;
+  height: 200px;
   border: 1px solid #e5e7eb;
-  border-radius: 0.5rem;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-  margin-top: 1rem;
+  border-radius: 0.75rem;
+  box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+  overflow: hidden;
 }
 
 .day-content {
@@ -172,6 +173,13 @@ h1, h2, h3, blockquote {
 .day-content .left,
 .day-content .right {
   flex: 1;
+}
+
+.day-content .right {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
 }
 
 .day-content .travel-icons {


### PR DESCRIPTION
## Summary
- Make mini-map responsive with relative sizing and enhanced styling
- Use flex layout on parent container to keep the map aligned within its card

## Testing
- `python -m py_compile server.py build.py`


------
https://chatgpt.com/codex/tasks/task_e_68966957eb1083208f19807618f4832d