### PR TITLE
Stop changing day from global map markers

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -72,8 +72,8 @@ async function initMap() {
           markerManager.markers.forEach(m => {
             if (m !== marker) m.closePopup();
           });
+          marker.openPopup();
           marker.openTooltip();
-          showDay(entry.days[0]);
         });
       }
     });


### PR DESCRIPTION
## Summary
- remove `showDay` call from global map marker click events
- keep marker popup and tooltip opening only

## Testing
- `node --check static/js/app.js`

------
https://chatgpt.com/codex/tasks/task_e_68966ad6a0988320af737f37bba963d6