### PR TITLE
Enable interactive mini-map markers

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -158,6 +158,7 @@ h1, h2, h3, blockquote {
   width: 100%;
   max-width: 300px;
   height: 200px;
+  margin: 0 auto;
   border: 1px solid #e5e7eb;
   border-radius: 0.75rem;
   box-shadow: 0 4px 8px rgba(0,0,0,0.1);

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -74,6 +74,7 @@ async function initMap() {
           });
           marker.openPopup();
           marker.openTooltip();
+          showDay(point.day);
         });
       }
     });
@@ -247,17 +248,20 @@ function showDay(dayNumber, button) {
     const latlngs = points.map(p => [p.lat, p.lng]);
     mini = createMap(miniMap, {
       attributionControl: false,
-      interactive: false
+      interactive: true,
+      zoomControl: true
     });
 
-    latlngs.forEach(coord => {
-      L.marker(coord)
-        .addTo(mini)
-        .on('click', () => showDay(day.day));
+    points.forEach(step => {
+      const marker = L.marker([step.lat, step.lng]).addTo(mini);
+      if (step.name) {
+        marker.bindPopup(step.name);
+      }
+      marker.on('click', () => showDay(step.day ?? day.day));
     });
 
     if (latlngs.length > 1) {
-      L.polyline(latlngs).addTo(mini);
+      L.polyline(latlngs, { color: '#2563eb', weight: 3 }).addTo(mini);
     }
 
     const bounds = L.latLngBounds(latlngs);


### PR DESCRIPTION
## Summary
- Allow mini-map to be interactive with zoom controls
- Bind step markers with popups and day selection
- Center mini-map styling for better visibility

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689676619c708320bb56453bb3488495