### PR TITLE
Refactor programme section layout and mini-map container

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,9 +97,14 @@
     </section>
 
   <section id="programme" class="py-8 mb-8">
-    <h2 class="text-3xl font-bold mb-4 text-center">Notre parcours jour par jour</h2>
-    <div id="sidebar-programme"></div>
-    <div id="jour-detail"></div>
+    <h2 id="programme-title" class="text-3xl font-bold mb-4 text-center">Notre parcours jour par jour</h2>
+    <div class="programme-layout">
+      <aside id="programme-menu" class="programme-menu" aria-label="Jours du programme"></aside>
+      <section id="programme-detail" class="programme-detail">
+        <div id="jour-detail"></div>
+        <div id="mini-map" class="mini-map" aria-label="Mini-carte du jour sélectionné"></div>
+      </section>
+    </div>
   </section>
 
   <section id="infos"></section>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -309,14 +309,17 @@ h1, h2, h3, blockquote {
 
 /* Programme section layout */
 #programme {
-  display: flex;
-  align-items: flex-start;
-  gap: 2rem;
   margin: 2rem 0 3rem;
   padding: 2rem 0;
 }
 
-#sidebar-programme {
+.programme-layout {
+  display: flex;
+  align-items: flex-start;
+  gap: 2rem;
+}
+
+#programme-menu {
   width: 220px;
   height: 100vh;
   overflow-y: auto;
@@ -330,7 +333,14 @@ h1, h2, h3, blockquote {
   top: 0;
 }
 
-#sidebar-programme button {
+#programme-detail {
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+#programme-menu button {
   padding: 0.5rem 0.75rem;
   background: transparent;
   border: 2px solid transparent;
@@ -340,7 +350,7 @@ h1, h2, h3, blockquote {
   transition: background 0.3s, border 0.3s;
 }
 
-#sidebar-programme button:hover {
+#programme-menu button:hover {
   background: #e5e7eb;
 }
 
@@ -372,10 +382,10 @@ h1, h2, h3, blockquote {
 }
 
 @media (max-width: 768px) {
-  #programme {
+  .programme-layout {
     flex-direction: column;
   }
-  #sidebar-programme {
+  #programme-menu {
     width: 100%;
     flex-direction: row;
     overflow-x: auto;
@@ -383,7 +393,7 @@ h1, h2, h3, blockquote {
     white-space: nowrap;
     -webkit-overflow-scrolling: touch;
   }
-  #sidebar-programme button {
+  #programme-menu button {
     flex: 0 0 auto;
     padding: 0.5rem 1rem;
     font-size: 0.875rem;
@@ -410,7 +420,7 @@ h1, h2, h3, blockquote {
 }
 
 @media (max-width: 480px) {
-  #sidebar-programme button {
+  #programme-menu button {
     padding: 0.5rem;
     font-size: 0.75rem;
   }

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -134,7 +134,7 @@ async function loadTripData() {
 
 // Render navigation
 function renderNavigation(data) {
-  const nav = document.getElementById('sidebar-programme');
+  const nav = document.getElementById('programme-menu');
   nav.innerHTML = '';
   data.forEach(day => {
     const btn = document.createElement('button');
@@ -156,14 +156,16 @@ function showDay(dayNumber, button) {
       return;
     }
 
-    const sidebar = document.getElementById('sidebar-programme');
+    const sidebar = document.getElementById('programme-menu');
     const detailContainer = document.getElementById('jour-detail');
+    const miniMapContainer = document.getElementById('mini-map');
 
     // Clean previous mini-map instance to avoid memory leaks
     if (mini) {
       mini.remove();
       mini = null;
     }
+    miniMapContainer.innerHTML = '';
     sidebar.querySelectorAll('button').forEach(btn => btn.classList.remove('selected'));
     const targetBtn = button || sidebar.querySelector(`button[data-day="${dayNum}"]`);
     if (targetBtn) {
@@ -235,10 +237,6 @@ function showDay(dayNumber, button) {
     img.onerror = () => { img.src = `jour${day.day}.png`; };
     rightCol.appendChild(img);
 
-    const miniMap = document.createElement('div');
-    miniMap.classList.add('mini-map');
-    rightCol.appendChild(miniMap);
-
     // Initialize mini-map for the selected day
     const points = Array.isArray(day.coords)
       ? day.coords
@@ -246,7 +244,7 @@ function showDay(dayNumber, button) {
         ? day.steps
         : [{ lat: day.lat, lng: day.lng }];
     const latlngs = points.map(p => [p.lat, p.lng]);
-    mini = createMap(miniMap, {
+    mini = createMap(miniMapContainer, {
       attributionControl: false,
       interactive: true,
       zoomControl: true


### PR DESCRIPTION
## Summary
- Replace programme sidebar and detail markup with structured layout and dedicated mini-map container
- Adjust styling for new programme menu and layout, ensuring title sits above content
- Update app logic to target new IDs and render mini-map in separate container

## Testing
- `node --check static/js/app.js`


------
https://chatgpt.com/codex/tasks/task_e_6896839da250832091717ad186b35b12