### PR TITLE
Refactor mini-map and programme detail handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,7 +101,6 @@
     <div class="programme-layout">
       <aside id="programme-menu" class="programme-menu" aria-label="Jours du programme"></aside>
       <section id="programme-detail" class="programme-detail">
-        <div id="jour-detail"></div>
         <div id="mini-map" class="mini-map" aria-label="Mini-carte du jour sélectionné"></div>
       </section>
     </div>


### PR DESCRIPTION
## Summary
- Use `#programme-menu` and `#programme-detail` selectors across the app
- Rebuild `showDay` mini-map logic to load and filter KML data per day
- Keep a persistent `#mini-map` container and reuse it across days

## Testing
- `node --check static/js/app.js`


------
https://chatgpt.com/codex/tasks/task_e_6896888c93ac83208a3d69c654971676