### PR TITLE
Improve day navigation accessibility

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -6,6 +6,10 @@
   border-radius: 0.5rem;
   transition: all 0.2s;
 }
+.day-button:focus {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
+}
 .day-button:hover {
   background-color: #eff6ff;
 }

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -136,14 +136,24 @@ async function loadTripData() {
 function renderNavigation(data) {
   const nav = document.getElementById('programme-menu');
   nav.innerHTML = '';
+  const list = document.createElement('ul');
+  list.setAttribute('role', 'listbox');
+
   data.forEach(day => {
+    const listItem = document.createElement('li');
     const btn = document.createElement('button');
     btn.textContent = `Jour ${day.day}`;
     btn.classList.add('day-button');
     btn.dataset.day = day.day;
+    btn.setAttribute('role', 'option');
+    btn.setAttribute('tabindex', '0');
+    btn.setAttribute('aria-selected', 'false');
     btn.addEventListener('click', () => showDay(day.day, btn));
-    nav.appendChild(btn);
+    listItem.appendChild(btn);
+    list.appendChild(listItem);
   });
+
+  nav.appendChild(list);
 }
 
 // Show day content
@@ -165,10 +175,14 @@ function showDay(dayNumber, button) {
       miniMap.remove();
     }
     miniMapContainer.innerHTML = '';
-    sidebar.querySelectorAll('button').forEach(btn => btn.classList.remove('selected'));
+    sidebar.querySelectorAll('button').forEach(btn => {
+      btn.classList.remove('selected');
+      btn.setAttribute('aria-selected', 'false');
+    });
     const targetBtn = button || sidebar.querySelector(`button[data-day="${dayNum}"]`);
     if (targetBtn) {
       targetBtn.classList.add('selected');
+      targetBtn.setAttribute('aria-selected', 'true');
       targetBtn.scrollIntoView({ behavior: 'smooth', block: 'center' });
     }
 


### PR DESCRIPTION
## Summary
- Wrap day navigation in a semantic listbox and expose each day as an option with appropriate ARIA roles and tab index
- Track active day selection via `aria-selected` and update when changing days
- Add visible focus outline for day buttons to aid keyboard navigation

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68968aa5c1548320a2d031b839553d6e