### PR TITLE
Use shared sticky offset for scroll

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -289,6 +289,14 @@ function showDay(dayNumber, button) {
     detailContainer.addEventListener('animationend', () => {
       detailContainer.classList.remove('fade-in');
     }, { once: true });
+
+    if (button) {
+      const programmeTitle = document.getElementById('programme-title');
+      if (programmeTitle) {
+        const top = programmeTitle.getBoundingClientRect().top + window.scrollY - STICKY_OFFSET;
+        window.scrollTo({ top, behavior: 'smooth' });
+      }
+    }
   } catch (error) {
     console.error('Error showing day:', error);
     document.getElementById('programme-detail').innerHTML = `

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -1,3 +1,5 @@
+const STICKY_OFFSET = 80;
+
 document.addEventListener('DOMContentLoaded', () => {
   const button = document.getElementById('mobile-menu-button');
   const nav = document.getElementById('side-nav');


### PR DESCRIPTION
## Summary
- Expose a shared `STICKY_OFFSET` constant for header height
- Scroll programme section using this offset to prevent sticky header overlap

## Testing
- `node --check static/js/common.js static/js/app.js`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68968ba156f08320971701be6db951a8