### PR TITLE
Use relative KML path for maps

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1,6 +1,7 @@
 // Global variables
 let map;
 let miniMap; // mini-map instance
+const KML_PATH = './circuit-voyage-usa.kml';
 const markerManager = {
   markers: new Map(),
   addMarker(day, marker) {
@@ -82,7 +83,7 @@ async function initMap() {
 
   // Charger le tracé KML (sans les points, déjà gérés)
   console.log('Loading KML file...');
-  omnivore.kml('./circuit-voyage-usa.kml')
+  omnivore.kml(KML_PATH)
     .on('ready', async function() {
       console.log('KML file loaded successfully');
       this.eachLayer(function(layer) {
@@ -258,7 +259,7 @@ function showDay(dayNumber, button) {
       zoomControl: true
     });
 
-    omnivore.kml('/Voyage-USA/circuit-voyage-usa.kml')
+    omnivore.kml(KML_PATH)
       .on('ready', function() {
         const layers = [];
         this.eachLayer(layer => {


### PR DESCRIPTION
## Summary
- define a shared `KML_PATH` constant for the circuit KML file
- load the KML using this relative path in both main and mini maps

## Testing
- `node --check static/js/app.js`
- `node -e "require('fs').access('circuit-voyage-usa.kml', require('fs').constants.R_OK, err => { if(err) { console.error('Missing KML'); } else { console.log('KML accessible'); } })"`


------
https://chatgpt.com/codex/tasks/task_e_689699484598832093a60e7421c92f52