### PR TITLE
Equalize itinerary map and key figures height

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -218,23 +218,30 @@ h1, h2, h3, blockquote {
 .itineraire-wrapper {
   display: flex;
   gap: 2rem;
-  align-items: flex-start;
+  align-items: stretch;
   margin-bottom: 2rem;
 }
 
 .map-zone {
   flex: 2;
+  display: flex;
+  height: 100%;
 }
 
 .chiffres-cles {
   flex: 1;
   display: flex;
   flex-direction: column;
+  height: 100%;
   gap: 1rem;
   background: #fff;
   padding: 1rem;
   border-radius: 0.5rem;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+#map-container {
+  flex: 1;
 }
 
 .stat-item {


### PR DESCRIPTION
## Summary
- stretch itinerary wrapper alignment so map and key figures take same height
- make map zone and key figures flex children with full height; allow map container to flex

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python server.py > /tmp/server.log 2>&1 &`; `curl -I localhost:8000/index.html`


------
https://chatgpt.com/codex/tasks/task_e_6896a13cb408832090bc4919e7323fa2