### PR TITLE
Ensure header anchor links respect sticky offset

### DIFF
--- a/static/js/common.js
+++ b/static/js/common.js
@@ -9,6 +9,18 @@ document.addEventListener('DOMContentLoaded', () => {
       nav.classList.toggle('show');
     });
   }
+
+  const links = document.querySelectorAll('header nav a[href^="#"]');
+  links.forEach(link => {
+    link.addEventListener('click', event => {
+      event.preventDefault();
+      const target = document.querySelector(link.getAttribute('href'));
+      if (target) {
+        const top = target.getBoundingClientRect().top + window.scrollY - STICKY_OFFSET;
+        window.scrollTo({ top, behavior: 'smooth' });
+      }
+    });
+  });
 });
 
 function createMap(container, options = {}) {


### PR DESCRIPTION
## Summary
- Intercept clicks on header anchor links to apply smooth scrolling
- Account for sticky header height using STICKY_OFFSET when navigating

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689715ce33c483209d21fe058c51f95a