### PR TITLE
Calculate header offset dynamically for smooth scroll

### DIFF
--- a/static/js/common.js
+++ b/static/js/common.js
@@ -1,5 +1,3 @@
-const STICKY_OFFSET = 80;
-
 document.addEventListener('DOMContentLoaded', () => {
   const button = document.getElementById('mobile-menu-button');
   const nav = document.getElementById('side-nav');
@@ -10,13 +8,16 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
+  const header = document.querySelector('header');
+  const offset = header ? header.offsetHeight : 0;
+
   const links = document.querySelectorAll('header nav a[href^="#"]');
   links.forEach(link => {
     link.addEventListener('click', event => {
       event.preventDefault();
       const target = document.querySelector(link.getAttribute('href'));
       if (target) {
-        const top = target.getBoundingClientRect().top + window.scrollY - STICKY_OFFSET;
+        const top = target.getBoundingClientRect().top + window.scrollY - offset;
         window.scrollTo({ top, behavior: 'smooth' });
       }
     });


### PR DESCRIPTION
## Summary
- compute header height on DOMContentLoaded
- use dynamic offset instead of STICKY_OFFSET for in-page navigation
- remove obsolete STICKY_OFFSET constant

## Testing
- `node /tmp/test_common.js`
- `python server.py &` and `curl -I http://localhost:8000/index.html`
- `curl -I http://localhost:8000/roadtrip_usa_2026.html`


------
https://chatgpt.com/codex/tasks/task_e_6897192f6224832084f6da6bade263e6