### PR TITLE
feat: enable horizontal menu scrolling

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -18,6 +18,14 @@
   color: white;
 }
 
+@media (max-width: 900px) {
+  .day-button {
+    width: auto;
+    text-align: center;
+    flex: 0 0 auto;
+  }
+}
+
 /* Timeline styling */
 .timeline-item::before {
   content: '';

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -353,6 +353,17 @@ h1, h2, h3, blockquote {
     overflow-x: auto;
     white-space: nowrap;
   }
+  #programme-menu ul {
+    display: flex;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    gap: 0.5rem;
+    scroll-snap-type: x mandatory;
+  }
+  #programme-menu li {
+    flex: 0 0 auto;
+    scroll-snap-align: start;
+  }
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- Add responsive flex and scroll snapping for `#programme-menu` items
- Allow `.day-button` to size automatically on narrow screens

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68971b2f2de483208fc5e09c00f84272