### PR TITLE
Make programme menu static on narrow screens

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -349,9 +349,14 @@ h1, h2, h3, blockquote {
     grid-template-columns: 1fr;
   }
   .programme-menu {
+    position: static;
+    top: auto;
+    max-height: none;
     display: flex;
     overflow-x: auto;
+    overflow-y: visible;
     white-space: nowrap;
+    margin-bottom: 1rem;
   }
   #programme-menu ul {
     display: flex;


### PR DESCRIPTION
## Summary
- Reset `.programme-menu` positioning to static and removed its mobile max-height
- Added spacing so the menu sits above the content on small screens

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68971c24c288832089204257d754de9f