### PR TITLE
Reset mini-map container before recreation

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -175,7 +175,10 @@ function showDay(dayNumber, button) {
     // Clean previous mini-map instance to avoid memory leaks
     if (miniMap) {
       miniMap.remove();
+      miniMap = null;
     }
+    const container = L.DomUtil.get('mini-map');
+    if (container) container._leaflet_id = null;
     miniMapContainer.innerHTML = '';
     sidebar.querySelectorAll('button').forEach(btn => {
       btn.classList.remove('selected');


### PR DESCRIPTION
## Summary
- Reset mini-map instance and clear stale Leaflet container ID before building a new map

## Testing
- `npm test` *(fails: ENOENT no package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689720a0cf5c8320b788cba8818ccd4e