### PR TITLE
Add accessible mobile side navigation

### DIFF
--- a/roadtrip_usa_2026.html
+++ b/roadtrip_usa_2026.html
@@ -14,7 +14,12 @@
     <div class="max-w-7xl mx-auto px-4">
       <div class="flex items-center justify-between h-16">
         <h1 class="text-xl font-bold">Road Trip USA 2026</h1>
-        <nav class="flex space-x-4">
+        <button id="mobile-menu-button" class="md:hidden p-2" aria-label="Menu" aria-controls="side-nav" aria-expanded="false">
+          <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+        </button>
+        <nav class="hidden md:flex space-x-4">
           <a href="#accueil" class="hover:text-blue-500">Accueil</a>
           <a href="#itineraire" class="hover:text-blue-500">Itinéraire</a>
           <a href="#programme" class="hover:text-blue-500">Programme</a>
@@ -30,10 +35,10 @@
   <section id="programme" class="py-8 mb-8">
     <main>
       <!-- Sidebar -->
-      <aside id="side-nav" class="side-nav p-4 hidden md:block">
+      <nav id="side-nav" class="side-nav hidden md:flex md:flex-col p-4" aria-hidden="true" tabindex="-1">
         <h2 class="text-lg font-semibold mb-4">Jours</h2>
         <div id="nav-buttons" class="space-y-2"></div>
-      </aside>
+      </nav>
 
       <!-- Content -->
       <section id="content">

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -61,11 +61,19 @@
     position: fixed;
     inset: 0;
     z-index: 40;
+    transition: transform 0.3s ease-in-out, opacity 0.3s ease-in-out;
+    background-color: white;
     transform: translateX(-100%);
-    transition: transform 0.3s ease-in-out;
+  }
+  .side-nav.hidden {
+    display: block !important;
+    opacity: 0;
+    pointer-events: none;
   }
   .side-nav.show {
     transform: translateX(0);
+    opacity: 1;
+    pointer-events: auto;
   }
 }
 

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -2,9 +2,30 @@ document.addEventListener('DOMContentLoaded', () => {
   const button = document.getElementById('mobile-menu-button');
   const nav = document.getElementById('side-nav');
   if (button && nav) {
+    const focusableSelectors = 'a, button, [tabindex]:not([tabindex="-1"])';
     button.addEventListener('click', () => {
-      nav.classList.toggle('hidden');
-      nav.classList.toggle('show');
+      const expanded = button.getAttribute('aria-expanded') === 'true';
+
+      if (expanded) {
+        nav.classList.remove('show');
+        nav.addEventListener(
+          'transitionend',
+          () => {
+            nav.classList.add('hidden');
+            nav.setAttribute('aria-hidden', 'true');
+            button.focus();
+          },
+          { once: true }
+        );
+      } else {
+        nav.classList.remove('hidden');
+        requestAnimationFrame(() => nav.classList.add('show'));
+        nav.setAttribute('aria-hidden', 'false');
+        const first = nav.querySelector(focusableSelectors);
+        (first || nav).focus();
+      }
+
+      button.setAttribute('aria-expanded', String(!expanded));
     });
   }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,7 +7,7 @@
 <main class="min-h-screen relative">
   <div class="flex">
     <!-- Side navigation -->
-    <nav id="side-nav" class="side-nav w-72 bg-white shadow-lg h-[calc(100vh-200px)] sticky top-16 overflow-y-auto hidden md:block">
+    <nav id="side-nav" class="side-nav hidden md:flex md:flex-col w-72 bg-white shadow-lg h-[calc(100vh-200px)] sticky top-16 overflow-y-auto" aria-hidden="true" tabindex="-1">
       <div class="p-6">
         <div class="text-2xl font-bold mb-6 text-blue-600">Programme du voyage</div>
         <div id="days-nav" class="space-y-2">

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -14,7 +14,7 @@
     <div class="max-w-7xl mx-auto px-4">
       <div class="flex items-center justify-between h-16">
         <h1 class="text-xl font-bold">Road Trip USA 2026</h1>
-        <button id="mobile-menu-button" class="md:hidden p-2" aria-label="Menu">
+        <button id="mobile-menu-button" class="md:hidden p-2" aria-label="Menu" aria-controls="side-nav" aria-expanded="false">
           <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
           </svg>

--- a/templates/roadtrip_usa_2026.html
+++ b/templates/roadtrip_usa_2026.html
@@ -1,9 +1,9 @@
 <main>
   <!-- Sidebar -->
-  <aside id="side-nav" class="side-nav p-4 hidden md:block">
+  <nav id="side-nav" class="side-nav hidden md:flex md:flex-col p-4" aria-hidden="true" tabindex="-1">
     <h2 class="text-lg font-semibold mb-4">Jours</h2>
     <div id="nav-buttons" class="space-y-2"></div>
-  </aside>
+  </nav>
 
   <!-- Content -->
   <section id="content">


### PR DESCRIPTION
## Summary
- make side navigation responsive with `hidden`/`md:flex` layout and ARIA hooks
- add CSS transitions to slide the menu in and out
- enhance JS to toggle visibility, manage focus, and update accessibility attributes

## Testing
- `node --check static/js/common.js`

------
https://chatgpt.com/codex/tasks/task_e_6897266f37488320a488beeab2dc6b32