### PR TITLE
Disable day refresh on map marker click

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -76,7 +76,7 @@ async function initMap() {
           });
           marker.openPopup();
           marker.openTooltip();
-          showDay(point.day);
+          // showDay(point.day);
         });
       }
     });


### PR DESCRIPTION
## Summary
- Prevent main map markers from refreshing the daily program when clicked

## Testing
- `node --check static/js/app.js`


------
https://chatgpt.com/codex/tasks/task_e_689729e1e44c8320a7fd3e2a3bbd0f16