### PR TITLE
Hide top nav on mobile and scope styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
           </svg>
         </button>
       </div>
-      <nav class="flex space-x-4 justify-center py-2">
+      <nav class="top-nav hidden md:flex space-x-4 justify-center py-2">
         <a href="#accueil">Accueil</a>
         <a href="#itineraire">Itinéraire</a>
         <a href="#programme">Programme</a>

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -60,7 +60,7 @@
   .side-nav {
     position: fixed;
     inset: 0;
-    z-index: 40;
+    z-index: 50;
     transition: transform 0.3s ease-in-out, opacity 0.3s ease-in-out;
     background-color: white;
     transform: translateX(-100%);

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -409,11 +409,11 @@ h1, h2, h3, blockquote {
   }
 }
 
-nav {
+.top-nav {
   position: sticky;
   top: 0;
   z-index: 999;
-  background-color: white; /* use site background color if different */
+  background-color: white;
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
 }
 


### PR DESCRIPTION
## Summary
- Hide top navigation on small screens and add `top-nav` class
- Scope header navigation styles to `.top-nav`
- Raise side navigation z-index to avoid being hidden by header

## Testing
- `python -m py_compile server.py`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897375c085c83208ec1c7fbda33259d