### PR TITLE
Add accessible mobile side navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     <div class="max-w-7xl mx-auto px-4">
       <div class="flex items-center justify-between h-16">
         <h1 class="text-xl font-bold">Road Trip USA 2026</h1>
-        <button id="mobile-menu-button" class="md:hidden p-2" aria-label="Menu">
+        <button id="mobile-menu-button" class="md:hidden p-2" aria-label="Menu" aria-controls="side-nav" aria-expanded="false">
           <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
           </svg>
@@ -30,6 +30,15 @@
       </nav>
     </div>
   </header>
+
+  <nav id="side-nav"
+       class="side-nav hidden p-4 space-y-4"
+       aria-hidden="true">
+    <a href="#accueil">Accueil</a>
+    <a href="#itineraire">Itinéraire</a>
+    <a href="#programme">Programme</a>
+    <a href="#infos">Infos pratiques</a>
+  </nav>
 
   <section id="accueil" class="hero">
     <div class="hero-text">

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -57,13 +57,19 @@
 
 /* Mobile menu */
 @media (max-width: 768px) {
-  .side-nav {
+  #side-nav.side-nav {
     position: fixed;
     inset: 0;
     z-index: 50;
     transition: transform 0.3s ease-in-out, opacity 0.3s ease-in-out;
     background-color: white;
     transform: translateX(-100%);
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    overflow-y: auto;
+    overflow-x: hidden;
+    padding: 1rem;
   }
   .side-nav.hidden {
     display: block !important;


### PR DESCRIPTION
## Summary
- insert mobile side navigation after header with links for main sections
- link mobile menu button to side navigation and add ARIA attributes
- style side navigation for vertical layout and smooth reveal on small screens

## Testing
- `python -m py_compile build.py server.py`


------
https://chatgpt.com/codex/tasks/task_e_68973a3ea2908320bc9c606de9d96a7d