### PR TITLE
Remove redundant mobile menu listener

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -321,13 +321,6 @@ function showDay(dayNumber, button) {
   }
 }
 
-
-// Mobile menu
-document.getElementById('mobile-menu-button').addEventListener('click', () => {
-  const nav = document.getElementById('side-nav');
-  nav.classList.toggle('hidden');
-});
-
 // Initialize
 window.addEventListener('load', async () => {
   console.log('Loading application...');


### PR DESCRIPTION
## Summary
- Remove duplicate mobile menu handler from app.js to avoid conflicting listeners

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68973bc103cc832084d27eddc74ab153