### PR TITLE
feat: adapt top navigation for mobile

### DIFF
--- a/static/css/roadtrip.css
+++ b/static/css/roadtrip.css
@@ -57,26 +57,28 @@ main {
 }
 
 /* Sticky top-right navigation menu */
-header nav {
-  position: fixed;
-  top: 0.5rem;
-  right: 0.5rem;
-  background-color: rgba(255, 255, 255, 0.95);
-  padding: 0.5rem 1rem;
-  display: flex;
-  gap: 1rem;
-  border-radius: 0.5rem;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-  z-index: 1000;
+@media (min-width: 768px) {
+  .top-nav {
+    position: fixed;
+    top: 0.5rem;
+    right: 0.5rem;
+    background-color: rgba(255, 255, 255, 0.95);
+    padding: 0.5rem 1rem;
+    display: flex;
+    gap: 1rem;
+    border-radius: 0.5rem;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    z-index: 1000;
+  }
 }
 
-header nav a {
+.top-nav a {
   color: #1f2937;
   text-decoration: none;
 }
 
-header nav a:focus,
-header nav a:hover {
+.top-nav a:focus,
+.top-nav a:hover {
   color: #1d4ed8;
 }
 


### PR DESCRIPTION
## Summary
- show top navigation only on desktop screens via media query
- update link styles to target `.top-nav` class

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `node --check static/js/common.js`
- `curl -I http://localhost:8000/index.html`
- `curl -I http://localhost:8000/static/css/roadtrip.css`


------
https://chatgpt.com/codex/tasks/task_e_68974077c5208320b0c20e52ad18bea1