### PR TITLE
Fix mobile side-nav transform

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -57,7 +57,7 @@
 
 /* Mobile menu */
 @media (max-width: 768px) {
-  #side-nav.side-nav {
+  .side-nav {
     position: fixed;
     inset: 0;
     z-index: 50;


### PR DESCRIPTION
## Summary
- Correct side-nav rule to class selector so show class can override transform

## Testing
- `npm test` (fails: Could not read package.json)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897444dad0083209f71be10d71f50ea