### PR TITLE
Handle side-nav links and close menu on click

### DIFF
--- a/static/js/common.js
+++ b/static/js/common.js
@@ -32,7 +32,9 @@ document.addEventListener('DOMContentLoaded', () => {
   const header = document.querySelector('header');
   const offset = header ? header.offsetHeight : 0;
 
-  const links = document.querySelectorAll('header nav a[href^="#"]');
+  const links = document.querySelectorAll(
+    '#side-nav a[href^="#"], header nav a[href^="#"]'
+  );
   links.forEach(link => {
     link.addEventListener('click', event => {
       event.preventDefault();
@@ -40,6 +42,12 @@ document.addEventListener('DOMContentLoaded', () => {
       if (target) {
         const top = target.getBoundingClientRect().top + window.scrollY - offset;
         window.scrollTo({ top, behavior: 'smooth' });
+      }
+
+      if (button && nav && nav.classList.contains('show')) {
+        nav.classList.remove('show');
+        nav.classList.add('hidden');
+        button.setAttribute('aria-expanded', 'false');
       }
     });
   });


### PR DESCRIPTION
## Summary
- include side-nav navigation links in smooth scroll handler
- collapse side menu and update button state after link navigation

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68974505def483209f43801f2a3cfe26