### PR TITLE
Add mobile menu overlay and close controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,6 +41,8 @@
       </div>
     </nav>
 
+    <div id="menu-overlay" class="menu-overlay hidden"></div>
+
     <!-- Main content area -->
     <div class="flex-1">
       <div id="day-content" class="max-w-7xl mx-auto p-6">

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -86,6 +86,23 @@
     opacity: 1;
     pointer-events: auto;
   }
+
+  .menu-overlay {
+    position: fixed;
+    inset: 0;
+    background-color: rgba(0, 0, 0, 0.5);
+    z-index: 20;
+    transition: opacity 0.3s ease-in-out;
+  }
+  .menu-overlay.hidden {
+    display: block !important;
+    opacity: 0;
+    pointer-events: none;
+  }
+  .menu-overlay.show {
+    opacity: 1;
+    pointer-events: auto;
+  }
 }
 
 /* Map marker styles */

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -1,31 +1,55 @@
 document.addEventListener('DOMContentLoaded', () => {
   const button = document.getElementById('mobile-menu-button');
   const nav = document.getElementById('side-nav');
-  if (button && nav) {
+  const overlay = document.getElementById('menu-overlay');
+  if (button && nav && overlay) {
     const focusableSelectors = 'a, button, [tabindex]:not([tabindex="-1"])';
+
+    const closeMenu = () => {
+      if (!nav.classList.contains('show')) return;
+      nav.classList.remove('show');
+      overlay.classList.remove('show');
+      nav.addEventListener(
+        'transitionend',
+        () => {
+          nav.classList.add('hidden');
+          overlay.classList.add('hidden');
+          nav.setAttribute('aria-hidden', 'true');
+          button.setAttribute('aria-expanded', 'false');
+          button.focus();
+        },
+        { once: true }
+      );
+    };
+
+    const openMenu = () => {
+      nav.classList.remove('hidden');
+      overlay.classList.remove('hidden');
+      requestAnimationFrame(() => {
+        nav.classList.add('show');
+        overlay.classList.add('show');
+      });
+      nav.setAttribute('aria-hidden', 'false');
+      button.setAttribute('aria-expanded', 'true');
+      const first = nav.querySelector(focusableSelectors);
+      (first || nav).focus();
+    };
+
     button.addEventListener('click', () => {
       const expanded = button.getAttribute('aria-expanded') === 'true';
-
       if (expanded) {
-        nav.classList.remove('show');
-        nav.addEventListener(
-          'transitionend',
-          () => {
-            nav.classList.add('hidden');
-            nav.setAttribute('aria-hidden', 'true');
-            button.focus();
-          },
-          { once: true }
-        );
+        closeMenu();
       } else {
-        nav.classList.remove('hidden');
-        requestAnimationFrame(() => nav.classList.add('show'));
-        nav.setAttribute('aria-hidden', 'false');
-        const first = nav.querySelector(focusableSelectors);
-        (first || nav).focus();
+        openMenu();
       }
+    });
 
-      button.setAttribute('aria-expanded', String(!expanded));
+    overlay.addEventListener('click', closeMenu);
+
+    document.addEventListener('keydown', e => {
+      if (e.key === 'Escape') {
+        closeMenu();
+      }
     });
   }
 
@@ -44,9 +68,11 @@ document.addEventListener('DOMContentLoaded', () => {
         window.scrollTo({ top, behavior: 'smooth' });
       }
 
-      if (button && nav && nav.classList.contains('show')) {
+      if (button && nav && overlay && nav.classList.contains('show')) {
         nav.classList.remove('show');
         nav.classList.add('hidden');
+        overlay.classList.remove('show');
+        overlay.classList.add('hidden');
         button.setAttribute('aria-expanded', 'false');
       }
     });


### PR DESCRIPTION
## Summary
- add overlay element for mobile navigation
- style overlay for full-screen dimming with show/hidden states
- support overlay and ESC-based closing in common.js

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm test` *(fails: ENOENT Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68974a17e0c88320a5deb8a0a46e55bc