### PR TITLE
Enhance side navigation spacing and active link styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,12 +32,15 @@
 <main class="min-h-screen relative">
   <div class="flex">
     <!-- Side navigation -->
-    <nav id="side-nav" class="side-nav hidden md:flex md:flex-col w-72 bg-white shadow-lg h-[calc(100vh-200px)] sticky top-16 overflow-y-auto" aria-hidden="true" tabindex="-1">
-      <div class="p-6">
-        <div class="text-2xl font-bold mb-6 text-blue-600">Programme du voyage</div>
-        <div id="days-nav" class="space-y-2">
-          <!-- Days navigation will be inserted here -->
-        </div>
+    <nav
+      id="side-nav"
+      class="side-nav hidden md:flex flex-col items-start gap-4 px-6 w-72 bg-white shadow-lg h-[calc(100vh-200px)] sticky top-16 overflow-y-auto"
+      aria-hidden="true"
+      tabindex="-1"
+    >
+      <div class="text-2xl font-bold text-blue-600">Programme du voyage</div>
+      <div id="days-nav" class="space-y-2 w-full">
+        <!-- Days navigation will be inserted here -->
       </div>
     </nav>
 

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -18,6 +18,25 @@
   color: white;
 }
 
+/* Side navigation links */
+.side-nav a {
+  display: block;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.5rem;
+  transition: background-color 0.2s, color 0.2s;
+}
+
+.side-nav a:hover {
+  background-color: #dbeafe;
+  color: #1d4ed8;
+}
+
+.side-nav a.active {
+  background-color: #2563eb;
+  color: #ffffff;
+  font-weight: 600;
+}
+
 @media (max-width: 900px) {
   .day-button {
     width: auto;

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -66,6 +66,9 @@ document.addEventListener('DOMContentLoaded', () => {
       if (target) {
         const top = target.getBoundingClientRect().top + window.scrollY - offset;
         window.scrollTo({ top, behavior: 'smooth' });
+
+        links.forEach(l => l.classList.remove('active'));
+        link.classList.add('active');
       }
 
       if (button && nav && overlay && nav.classList.contains('show')) {


### PR DESCRIPTION
## Summary
- apply flex column layout with padding to side navigation container
- add hover and active styles for side navigation links
- update scroll handler to toggle active link state

## Testing
- `npm test` *(fails: enoent package.json)*
- `pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68974b1cca24832092021b9e746c56cc