### PR TITLE
Rename program section IDs and add mini-map container

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,6 +88,7 @@
             </div>
           </div>
         </div>
+        <div id="mini-map" class="mini-map"></div>
       </div>
     </div>
   </div>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -321,14 +321,14 @@ h1, h2, h3, blockquote {
   gap: 24px;
 }
 
-.programme-menu {
+.days-nav {
   position: sticky;
   top: 80px;
   max-height: calc(100vh - 96px);
   overflow-y: auto;
 }
 
-.programme-detail {
+.day-content {
   max-width: 1100px;
   margin: 0;
 }
@@ -348,7 +348,7 @@ h1, h2, h3, blockquote {
   .programme-layout {
     grid-template-columns: 1fr;
   }
-  .programme-menu {
+  .days-nav {
     position: static;
     top: auto;
     max-height: none;
@@ -358,14 +358,14 @@ h1, h2, h3, blockquote {
     white-space: nowrap;
     margin-bottom: 1rem;
   }
-  #programme-menu ul {
+  #days-nav ul {
     display: flex;
     flex-wrap: nowrap;
     overflow-x: auto;
     gap: 0.5rem;
     scroll-snap-type: x mandatory;
   }
-  #programme-menu li {
+  #days-nav li {
     flex: 0 0 auto;
     scroll-snap-align: start;
   }

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -125,7 +125,7 @@ async function loadTripData() {
     return JSON.parse(text);
   } catch (error) {
     console.error('Error loading trip data:', error);
-      document.getElementById('programme-detail').innerHTML = `
+      document.getElementById('day-content').innerHTML = `
         <div class="text-red-600 p-4">
           Erreur de chargement : ${error.message}
         </div>
@@ -136,7 +136,7 @@ async function loadTripData() {
 
 // Render navigation
 function renderNavigation(data) {
-  const nav = document.getElementById('programme-menu');
+  const nav = document.getElementById('days-nav');
   nav.innerHTML = '';
   const list = document.createElement('ul');
   list.setAttribute('role', 'listbox');
@@ -168,8 +168,8 @@ function showDay(dayNumber, button) {
       return;
     }
 
-    const sidebar = document.getElementById('programme-menu');
-    const detailContainer = document.getElementById('programme-detail');
+    const sidebar = document.getElementById('days-nav');
+    const detailContainer = document.getElementById('day-content');
     const miniMapContainer = document.getElementById('mini-map');
 
     // Clean previous mini-map instance to avoid memory leaks
@@ -313,7 +313,7 @@ function showDay(dayNumber, button) {
     }
   } catch (error) {
     console.error('Error showing day:', error);
-    document.getElementById('programme-detail').innerHTML = `
+    document.getElementById('day-content').innerHTML = `
       <div class="text-red-600 p-4">
         Erreur lors du chargement du jour ${dayNumber}: ${error.message}
       </div>
@@ -338,7 +338,7 @@ window.addEventListener('load', async () => {
     
     // La navigation et l'affichage du jour 1 sont maintenant gérés après le chargement du KML
     if (!window.tripData) {
-      document.getElementById('programme-detail').innerHTML = `
+      document.getElementById('day-content').innerHTML = `
         <div class="text-red-600 p-4">
           Erreur: Impossible de charger les données du voyage.
           Vérifiez que le fichier itinerary.json est présent.
@@ -347,7 +347,7 @@ window.addEventListener('load', async () => {
     }
   } catch (error) {
     console.error('Error during initialization:', error);
-      document.getElementById('programme-detail').innerHTML = `
+      document.getElementById('day-content').innerHTML = `
         <div class="text-red-600 p-4">
           Erreur lors de l'initialisation: ${error.message}
         </div>


### PR DESCRIPTION
## Summary
- Replace `programme-menu` with `days-nav` and `programme-detail` with `day-content` across JS and CSS
- Insert `mini-map` container in the main content to support day-specific maps
- Update styles for new navigation and content IDs

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68974ddd7158832088721c3c0d18956e